### PR TITLE
fix: resolve mixed-returns

### DIFF
--- a/src/pkg_26548/run.py
+++ b/src/pkg_26548/run.py
@@ -424,6 +424,7 @@ def delete_workflow_runs(count, repo, workflow_run_id):  # pragma: no cover
 
     except GithubException as e:
         print(f'❌ Failed to delete workflow run {workflow_run_id}: {e}')
+        return None
 
 
 def get_api_estimate(orphan_runs_count, delete_runs_count):


### PR DESCRIPTION
<!-- NOTE: this file is managed by terraform -->
<!-- Describe the issue -->
#### Issue Summary
_CodeQL py/mixed-returns_

> When a function contains both explicit returns (return value) and implicit returns (where code falls off the end of a function), this often indicates that a return statement has been forgotten. It is best to return an explicit return value even when returning None because this makes it easier for other developers to read your code

<!-- What's the goal of the Pull Request? -->
#### Why's this PR created?

_This PR resolves CodeQL py/mixed-returns by adding a return None statement after delete_workflow_runs function gets exception_

